### PR TITLE
allow connect by url and set header based on full path

### DIFF
--- a/api.go
+++ b/api.go
@@ -158,11 +158,11 @@ func ConnectCredentials(host, port, version, userid, key string) (*Chef, error) 
 	return chef, nil
 }
 
-func ConnectUrl(chef_server_url, version, userid, key string) (*Chef, error) {
+func ConnectUrl(chefServerUrl, version, userid, key string) (*Chef, error) {
 	chef := new(Chef)
 	chef.Version = version
 	chef.UserId = userid
-	chef.Url = chef_server_url
+	chef.Url = chefServerUrl
 
 	var rsaKey *rsa.PrivateKey
 	var err error


### PR DESCRIPTION
I added a new method  - not sure it and the other connect is needed. Based on http://docs.opscode.com/api_chef_server.html

"HASHED_PATH is the path of the request (/name_of_endpoint for the open source server and /organizations/organization_name/name_of_endpoint for Hosted Chef or Private Chef)."

But I think as it is implemented, this code should work on both.  I don't have an open source server to test against, so no clue if it works there. 
