### PR TITLE
Refactor Middleware

### DIFF
--- a/api.go
+++ b/api.go
@@ -237,14 +237,7 @@ func (chef *Chef) buildQueryString(endpoint string, params map[string]string) (s
 
 // Get makes an authenticated HTTP request to the Chef server for the supplied
 // endpoint
-func (chef *Chef) Get(endpoint string) (*http.Response, error) {
-	request, _ := http.NewRequest("GET", chef.requestUrl(endpoint), nil)
-	return chef.makeRequest(request)
-}
-
-// GetWithParams makes an authenticated HTTP request to the Chef server for the
-// supplied endpoint and also includes GET query string parameters
-func (chef *Chef) GetWithParams(endpoint string, params map[string]string) (*http.Response, error) {
+func (chef *Chef) Get(endpoint string, params map[string]string) (*http.Response, error) {
 	query, err := chef.buildQueryString(endpoint, params)
 	if err != nil {
 		return nil, err

--- a/api_test.go
+++ b/api_test.go
@@ -175,7 +175,7 @@ func TestBuildQueryString(t *testing.T) {
 
 func TestGet(t *testing.T) {
 	c := testConnectionWrapper(t)
-	resp, err := c.Get("/cookbooks")
+	resp, err := c.Get("/cookbooks", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -208,7 +208,7 @@ func TestGetWithParams(t *testing.T) {
 	params := make(map[string]string)
 	params["q"] = "name:neo4j*"
 
-	resp, err := c.GetWithParams("/search/node", params)
+	resp, err := c.Get("/search/node", params)
 	if err != nil {
 		t.Error(err)
 	}

--- a/client.go
+++ b/client.go
@@ -36,7 +36,7 @@ type Client struct {
 //         fmt.Println("Client:", client)
 //     }
 func (chef *Chef) GetClients() (map[string]string, error) {
-	resp, err := chef.Get("clients")
+	resp, err := chef.Get("clients", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (chef *Chef) GetClients() (map[string]string, error) {
 //         fmt.Printf("%#v\n", client)
 //     }
 func (chef *Chef) GetClient(name string) (*Client, bool, error) {
-	resp, err := chef.Get(fmt.Sprintf("clients/%s", name))
+	resp, err := chef.Get(fmt.Sprintf("clients/%s", name), nil)
 	if err != nil {
 		return nil, false, err
 	}

--- a/cookbook.go
+++ b/cookbook.go
@@ -98,7 +98,7 @@ type CookbookItem struct {
 //         fmt.Println(name, cookbook.Version[0])
 //      }
 func (chef *Chef) GetCookbooks() (map[string]*Cookbook, error) {
-	resp, err := chef.Get("cookbooks")
+	resp, err := chef.Get("cookbooks", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func (chef *Chef) GetCookbooks() (map[string]*Cookbook, error) {
 //         fmt.Printf("%#v\n", cookbook)
 //     }
 func (chef *Chef) GetCookbook(name string) (*Cookbook, bool, error) {
-	resp, err := chef.Get(fmt.Sprintf("cookbooks/%s", name))
+	resp, err := chef.Get(fmt.Sprintf("cookbooks/%s", name), nil)
 	if err != nil {
 		return nil, false, err
 	}
@@ -177,7 +177,7 @@ func (chef *Chef) GetCookbook(name string) (*Cookbook, bool, error) {
 //         fmt.Printf("%#v\n", cookbook)
 //     }
 func (chef *Chef) GetCookbookVersion(name, version string) (*CookbookVersion, bool, error) {
-	resp, err := chef.Get(fmt.Sprintf("cookbooks/%s/%s", name, version))
+	resp, err := chef.Get(fmt.Sprintf("cookbooks/%s/%s", name, version), nil)
 	if err != nil {
 		return nil, false, err
 	}

--- a/data.go
+++ b/data.go
@@ -20,7 +20,7 @@ import (
 //         fmt.Println(d)
 //     }
 func (chef *Chef) GetData() (map[string]string, error) {
-	resp, err := chef.Get("data")
+	resp, err := chef.Get("data", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (chef *Chef) GetData() (map[string]string, error) {
 //         fmt.Println(data)
 //     }
 func (chef *Chef) GetDataByName(name string) (map[string]string, bool, error) {
-	resp, err := chef.Get(fmt.Sprintf("data/%s", name))
+	resp, err := chef.Get(fmt.Sprintf("data/%s", name), nil)
 	if err != nil {
 		return nil, false, err
 	}

--- a/environment.go
+++ b/environment.go
@@ -35,7 +35,7 @@ type Environment struct {
 //         fmt.Println(environment)
 //      }
 func (chef *Chef) GetEnvironments() (map[string]string, error) {
-	resp, err := chef.Get("environments")
+	resp, err := chef.Get("environments", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func (chef *Chef) GetEnvironments() (map[string]string, error) {
 //         fmt.Printf("%#v\n", environment)
 //     }
 func (chef *Chef) GetEnvironment(name string) (*Environment, bool, error) {
-	resp, err := chef.Get(fmt.Sprintf("environments/%s", name))
+	resp, err := chef.Get(fmt.Sprintf("environments/%s", name), nil)
 	if err != nil {
 		return nil, false, err
 	}
@@ -108,7 +108,7 @@ func (chef *Chef) GetEnvironment(name string) (*Environment, bool, error) {
 //         fmt.Println(name, cookbook.Version[0])
 //      }
 func (chef *Chef) GetEnvironmentCookbooks(name string) (map[string]*Cookbook, error) {
-	resp, err := chef.Get(fmt.Sprintf("environments/%s/cookbooks", name))
+	resp, err := chef.Get(fmt.Sprintf("environments/%s/cookbooks", name), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +144,7 @@ func (chef *Chef) GetEnvironmentCookbooks(name string) (map[string]*Cookbook, er
 //         fmt.Printf("%#v\n", cookbook)
 //     }
 func (chef *Chef) GetEnvironmentCookbook(env, cb string) (*Cookbook, bool, error) {
-	resp, err := chef.Get(fmt.Sprintf("environments/%s/cookbooks/%s", env, cb))
+	resp, err := chef.Get(fmt.Sprintf("environments/%s/cookbooks/%s", env, cb), nil)
 	if err != nil {
 		return nil, false, err
 	}
@@ -181,7 +181,7 @@ func (chef *Chef) GetEnvironmentCookbook(env, cb string) (*Cookbook, bool, error
 //         fmt.Println(node)
 //      }
 func (chef *Chef) GetEnvironmentNodes(name string) (map[string]string, error) {
-	resp, err := chef.Get(fmt.Sprintf("environments/%s/nodes", name))
+	resp, err := chef.Get(fmt.Sprintf("environments/%s/nodes", name), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +213,7 @@ func (chef *Chef) GetEnvironmentNodes(name string) (map[string]string, error) {
 //         fmt.Println(recipe)
 //      }
 func (chef *Chef) GetEnvironmentRecipes(name string) ([]string, error) {
-	resp, err := chef.Get(fmt.Sprintf("environments/%s/recipes", name))
+	resp, err := chef.Get(fmt.Sprintf("environments/%s/recipes", name), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +250,7 @@ func (chef *Chef) GetEnvironmentRecipes(name string) ([]string, error) {
 //         fmt.Println(role)
 //     }
 func (chef *Chef) GetEnvironmentRole(env, rol string) (map[string][]string, bool, error) {
-	resp, err := chef.Get(fmt.Sprintf("environments/%s/roles/%s", env, rol))
+	resp, err := chef.Get(fmt.Sprintf("environments/%s/roles/%s", env, rol), nil)
 	if err != nil {
 		return nil, false, err
 	}

--- a/node.go
+++ b/node.go
@@ -92,7 +92,7 @@ type Node struct {
 //         fmt.Println(node)
 //      }
 func (chef *Chef) GetNodes() (map[string]string, error) {
-	resp, err := chef.Get("nodes")
+	resp, err := chef.Get("nodes", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (chef *Chef) GetNodes() (map[string]string, error) {
 //         fmt.Printf("%#v\n", node)
 //     }
 func (chef *Chef) GetNode(name string) (*Node, bool, error) {
-	resp, err := chef.Get(fmt.Sprintf("nodes/%s", name))
+	resp, err := chef.Get(fmt.Sprintf("nodes/%s", name), nil)
 	if err != nil {
 		return nil, false, err
 	}

--- a/principal.go
+++ b/principal.go
@@ -28,7 +28,7 @@ import (
 //         fmt.Println(principal)
 //     }
 func (chef *Chef) GetPrincipal(name string) (map[string]string, bool, error) {
-	resp, err := chef.Get(fmt.Sprintf("principals/%s", name))
+	resp, err := chef.Get(fmt.Sprintf("principals/%s", name), nil)
 	if err != nil {
 		return nil, false, err
 	}

--- a/role.go
+++ b/role.go
@@ -33,7 +33,7 @@ type Role struct {
 //         fmt.Println(role)
 //      }
 func (chef *Chef) GetRoles() (map[string]string, error) {
-	resp, err := chef.Get("roles")
+	resp, err := chef.Get("roles", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (chef *Chef) GetRoles() (map[string]string, error) {
 //         fmt.Printf("%#v\n", role)
 //     }
 func (chef *Chef) GetRole(name string) (*Role, bool, error) {
-	resp, err := chef.Get(fmt.Sprintf("roles/%s", name))
+	resp, err := chef.Get(fmt.Sprintf("roles/%s", name), nil)
 	if err != nil {
 		return nil, false, err
 	}

--- a/search.go
+++ b/search.go
@@ -39,7 +39,7 @@ type SearchResults struct {
 //         fmt.Println(index)
 //      }
 func (chef *Chef) GetSearchIndexes() (map[string]string, error) {
-	resp, err := chef.Get("search")
+	resp, err := chef.Get("search", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func (search *SearchParams) Execute() (*SearchResults, error) {
 	if search.Sort != "" {
 		params["sort"] = search.Sort
 	}
-	resp, err := search.chef.GetWithParams(fmt.Sprintf("search/%s", search.Index), params)
+	resp, err := search.chef.Get(fmt.Sprintf("search/%s", search.Index), params)
 	if err != nil {
 		return nil, err
 	}

--- a/user.go
+++ b/user.go
@@ -20,7 +20,7 @@ import (
 //         fmt.Println(user)
 //      }
 func (chef *Chef) GetUsers() (map[string]string, error) {
-	resp, err := chef.Get("users")
+	resp, err := chef.Get("users", nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
chef.GetWithParams can also be serviced by chef.Get  This changes the internal calls to Get and GetWithParams to support this. 

This would break anything that might be calling Get or GetWithParams directly.  I think it is wise to  reduce this now.