### PR TITLE
Added some logic to enable uploading cookbooks

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -227,7 +227,7 @@ func TestPost(t *testing.T) {
 	config := testConfig()
 	cookbook := config.RequiredCookbook.Name
 	run_list := strings.NewReader(fmt.Sprintf(`{ "run_list": [ "%s" ] }`, cookbook))
-	resp, err := c.Post("/environments/_default/cookbook_versions", nil, run_list)
+	resp, err := c.Post("/environments/_default/cookbook_versions", "application/json", nil, run_list)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,7 +259,7 @@ func TestPost(t *testing.T) {
 	params["q"] = "name:neo4j*"
 
 	// For now this isn't supported in goiardi, but we can still submit it.
-	resp, err = c.Post("/search/node", params, partial_body)
+	resp, err = c.Post("/search/node", "application/json", params, partial_body)
 	if err != nil {
 		t.Error(err)
 	}

--- a/cookbook.go
+++ b/cookbook.go
@@ -53,14 +53,23 @@ type CookbookVersion struct {
 		CookbookItem
 	} `json:"root_files"`
 	Metadata struct {
-		Name            string            `json:"name"`
-		Description     string            `json:"description"`
-		LongDescription string            `json:"long_description"`
-		Maintainer      string            `json:"maintainer"`
-		MaintainerEmail string            `json:"maintainer_email"`
-		License         string            `json:"license"`
-		Providing       map[string]string `json:"providing"`
-		Dependencies    map[string]string `json:"dependencies"`
+		Name            string                 `json:"name"`
+		Description     string                 `json:"description"`
+		LongDescription string                 `json:"long_description"`
+		Maintainer      string                 `json:"maintainer"`
+		MaintainerEmail string                 `json:"maintainer_email"`
+		License         string                 `json:"license"`
+		Platforms       map[string]string      `json:"platforms"`
+		Dependencies    map[string]string      `json:"dependencies"`
+		Recommendations map[string]string      `json:"recommendations"`
+		Suggestions     map[string]string      `json:"suggestions"`
+		Conflicting     map[string]string      `json:"conflicting"`
+		Providing       map[string]string      `json:"providing"`
+		Replacing       map[string]string      `json:"replacing"`
+		Attributes      map[string]interface{} `json:"attributes"`
+		Groupings       map[string]interface{} `json:"groupings"`
+		Recipes         map[string]string      `json:"recipes"`
+		Version         string                 `json:"version"`
 	} `json:"metadata"`
 	Name      string `json:"cookbook_name"`
 	Version   string `json:"version"`


### PR DESCRIPTION
With this added code you can now post a cookbook to the community, or newly released supermarket, API. It does break backwards compatibility for post commands which with the current options seems the only way to make this work.

Please let's discus alternatives if this is not an acceptable approach. For example, one solution could be to make a PostCookbook method in addition to the Post method.

Cheers,

S.
