### PR TITLE
Without the 's' the root files are ignored

### DIFF
--- a/cookbook.go
+++ b/cookbook.go
@@ -51,7 +51,7 @@ type CookbookVersion struct {
 	} `json:"templates"`
 	RootFiles []struct {
 		CookbookItem
-	} `json:"root_file"`
+	} `json:"root_files"`
 	Metadata struct {
 		Name            string            `json:"name"`
 		Description     string            `json:"description"`


### PR DESCRIPTION
As without the 's' the json tag does not match the actual tag returned by the Chef server
