### PR TITLE
Add missing chef version info

### DIFF
--- a/api.go
+++ b/api.go
@@ -132,6 +132,9 @@ func Connect(filename ...string) (*Chef, error) {
 	if chef.Key == nil {
 		return nil, errors.New("missing 'client_key' in knife.rb")
 	}
+	if chef.Version == "" {
+		chef.Version = "11.6.0"
+	}
 
 	return chef, nil
 }


### PR DESCRIPTION
Requests would return `400 : Bad Request` without the version number.