### PR TITLE
Add the ProxyFromEnvironment option

### DIFF
--- a/api.go
+++ b/api.go
@@ -305,6 +305,7 @@ func (chef *Chef) makeRequest(request *http.Request) (*http.Response, error) {
 	var client *http.Client
 	if chef.SSLNoVerify {
 		tr := &http.Transport{
+                        Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
 		client = &http.Client{Transport: tr}


### PR DESCRIPTION
Without this option the client will not use your exported proxy settings. The default `http.Client` uses this option, but when you create a custom `http.Transport` you have to add it yourself...